### PR TITLE
API call fixed for productCategory page

### DIFF
--- a/src/pages/ProductsPage.jsx
+++ b/src/pages/ProductsPage.jsx
@@ -7,13 +7,14 @@ function ProductsPage({ productCategory }) {
 
   async function getProducts() {
     setShowLoader(true);
-    var response;
+    let response;
 
-    if(productCategory)
-    response = await fetch(`${process.env.REACT_APP_API_URL}/products/category/${productCategory}`);
-    
-    else
-    response = await fetch(`${process.env.REACT_APP_API_URL}/products/all`);
+    // Check if a productCategory exists and fetch accordingly
+    if (productCategory) {
+      response = await fetch(`${process.env.REACT_APP_API_URL}/products/category/${productCategory}`);
+    } else {
+      response = await fetch(`${process.env.REACT_APP_API_URL}/products/all`);
+    }
 
     if (response.ok) {
       const productsArray = await response.json();
@@ -22,9 +23,11 @@ function ProductsPage({ productCategory }) {
     setShowLoader(false);
   }
 
+  // Run getProducts whenever the productCategory prop changes
   useEffect(() => {
     getProducts();
-  }, []);
+  }, [productCategory]); // <-- Now the effect depends on productCategory
+
 
   return (
     <>


### PR DESCRIPTION
#4 
The issue we're facing comes from the fact that your useEffect hook in the ProductsPage component only runs once when the component mounts, which means it doesn't re-run when the productCategory prop changes.

In order to fix this, we need to update the useEffect dependency array so that it runs again when the productCategory prop changes. This will ensure that every time the category changes, the getProducts function is called to fetch the appropriate products.

**Solution**:
Add productCategory as a dependency to the useEffect hook so it will re-run every time the category changes.

![image](https://github.com/user-attachments/assets/33b9ae5e-2368-4124-b844-e96db0a7781d)
